### PR TITLE
Add student resources page

### DIFF
--- a/odontologia-admin/src/components/layouts/StudentLayout.vue
+++ b/odontologia-admin/src/components/layouts/StudentLayout.vue
@@ -30,6 +30,7 @@ const navItems: Array<{
   { name: 'ClinicalCases',      label: 'Casos Clínicos',      icon: 'fas fa-file-medical',    to: { name: 'ClinicalCases' } },
   { name: 'Assignments',        label: 'Tareas',              icon: 'fas fa-tasks',           to: { name: 'Assignments' } },
   { name: 'Communication',      label: 'Mensajes',            icon: 'fas fa-envelope',        to: { name: 'Communication' } },
+  { name: 'StudentResources',  label: 'Recursos',            icon: 'fas fa-book',            to: { name: 'StudentResources' } },
   { name: 'Odontogram',         label: 'Odontograma',         icon: 'fas fa-tooth',           to: { name: 'Odontogram' } }
 ]
 </script>

--- a/odontologia-admin/src/components/student/ResourcesLibrary.vue
+++ b/odontologia-admin/src/components/student/ResourcesLibrary.vue
@@ -1,0 +1,35 @@
+<template>
+  <div class="resources-library">
+    <div v-if="!items.length" class="text-muted">No hay recursos disponibles.</div>
+    <div class="row g-3">
+      <div v-for="r in items" :key="r.url" class="col-12 col-md-6 col-lg-4">
+        <div class="card h-100 shadow-sm">
+          <div class="card-body d-flex flex-column">
+            <h6 class="card-title">{{ r.title }}</h6>
+            <p class="flex-grow-1 small text-muted">{{ r.description }}</p>
+            <a :href="r.url" target="_blank" class="btn btn-primary mt-auto">
+              <i class="fas fa-external-link-alt me-1"></i> Abrir
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+interface Resource {
+  title: string
+  description: string
+  url: string
+}
+
+const props = defineProps<{ resources: Resource[] }>()
+const items = props.resources
+</script>
+
+<style scoped>
+.card-title {
+  font-weight: 600;
+}
+</style>

--- a/odontologia-admin/src/router/index.ts
+++ b/odontologia-admin/src/router/index.ts
@@ -34,6 +34,7 @@ const ClinicalCases         = () => import('@/views/student/ClinicalCasesView.vu
 const AssignmentsView       = () => import('@/views/student/AssignmentsView.vue')
 const CommunicationView     = () => import('@/views/student/CommunicationView.vue')
 const OdontogramView        = () => import('@/views/student/OdontogramView.vue')
+const StudentResources      = () => import('@/views/student/ResourcesView.vue')
 
 const routes: RouteRecordRaw[] = [
   { path: '/', redirect: '/login' },
@@ -89,6 +90,7 @@ const routes: RouteRecordRaw[] = [
       { path: 'cases',        name: 'ClinicalCases',    component: ClinicalCases },
       { path: 'assignments',  name: 'Assignments',      component: AssignmentsView },
       { path: 'communication', name: 'Communication',    component: CommunicationView },
+      { path: 'resources',    name: 'StudentResources', component: StudentResources },
       { path: 'odontogram',   name: 'Odontogram',       component: OdontogramView }
     ]
   },

--- a/odontologia-admin/src/views/student/ResourcesView.vue
+++ b/odontologia-admin/src/views/student/ResourcesView.vue
@@ -1,0 +1,42 @@
+<template>
+  <section class="container py-4">
+    <h1 class="mb-4">Biblioteca de Recursos</h1>
+    <ResourcesLibrary :resources="resources" />
+  </section>
+</template>
+
+<script setup lang="ts">
+import ResourcesLibrary from '../../components/student/ResourcesLibrary.vue'
+import { ref } from 'vue'
+
+interface Resource {
+  title: string
+  description: string
+  url: string
+}
+
+const resources = ref<Resource[]>([
+  {
+    title: 'Guía de procedimientos básicos',
+    description: 'Documento PDF con técnicas odontológicas fundamentales.',
+    url: 'https://example.com/procedimientos.pdf'
+  },
+  {
+    title: 'Video: higiene y esterilización',
+    description: 'Tutorial en video sobre prácticas de higiene en el consultorio.',
+    url: 'https://example.com/higiene.mp4'
+  },
+  {
+    title: 'Plantilla de historial clínico',
+    description: 'Formato descargable para registrar datos de pacientes.',
+    url: 'https://example.com/historial.docx'
+  }
+])
+</script>
+
+<style scoped>
+h1 {
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+</style>


### PR DESCRIPTION
## Summary
- add `ResourcesLibrary` component
- add `ResourcesView` page using the component
- include new route and navigation entry for student resources

## Testing
- `npm install`
- `npm run build` *(fails: various TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_6877200abd58832687249e51f3dd96b7